### PR TITLE
refactor: switch sql helper to mongodb

### DIFF
--- a/userbot/sql_helper/__init__.py
+++ b/userbot/sql_helper/__init__.py
@@ -7,11 +7,7 @@
 # Please see: https://github.com/TgCatUB/catuserbot/blob/master/LICENSE
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
 
-import os
-
-from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import scoped_session, sessionmaker
+from motor.motor_asyncio import AsyncIOMotorClient
 
 # the secret configuration specific things
 from ..Config import Config
@@ -20,24 +16,16 @@ from ..core.logger import logging
 LOGS = logging.getLogger(__name__)
 
 
-def start() -> scoped_session:
-    database_url = (
-        Config.DB_URI.replace("postgres:", "postgresql:")
-        if "postgres://" in Config.DB_URI
-        else Config.DB_URI
-    )
-    engine = create_engine(database_url)
-    BASE.metadata.bind = engine
-    BASE.metadata.create_all(engine)
-    return scoped_session(sessionmaker(bind=engine, autoflush=False))
-
+MONGO_DB_URI = getattr(Config, "MONGO_DB_URI", None) or Config.DB_URI
+MONGO_DB_NAME = getattr(Config, "MONGO_DB_NAME", "catuserbot")
 
 try:
-    BASE = declarative_base()
-    SESSION = start()
-except AttributeError as e:
-    # this is a dirty way for the work-around required for #23
+    MONGO_CLIENT = AsyncIOMotorClient(MONGO_DB_URI)
+    MONGO_DB = MONGO_CLIENT[MONGO_DB_NAME]
+except Exception as e:  # pragma: no cover - connection errors handled at runtime
     LOGS.error(
-        "DB_URI is not configured. Features depending on the database might have issues."
+        "MongoDB connection failed. Features depending on the database might have issues."
     )
     LOGS.error(str(e))
+    MONGO_CLIENT = None
+    MONGO_DB = None


### PR DESCRIPTION
## Summary
- replace SQLAlchemy/PostgreSQL session with Motor MongoDB client

## Testing
- `python -m py_compile userbot/sql_helper/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_68a1e18233708329b0e2866062e1d4ad